### PR TITLE
patched view select field type (value option converted to string)

### DIFF
--- a/packages/extensions/src/FieldType/Select/view.jade
+++ b/packages/extensions/src/FieldType/Select/view.jade
@@ -8,6 +8,6 @@
             option(value='') -- Please select --
             each option in $field.getOptions().options
                 option(
-                value= option,
+                value= option.toString(),
                 selected= option === value
                 )= option


### PR DESCRIPTION
Была выявлена бага:
Если widget Select применяется к полю boolean в sequelize, то значения true воспринимается браузером как инициализация этого атрибута ( то есть value="value" )