### PR TITLE
Stop using sequelize operator aliases on 'core' package, as advised for security reasons

### DIFF
--- a/packages/core/src/Utils/Sequelize/Query.js
+++ b/packages/core/src/Utils/Sequelize/Query.js
@@ -3,6 +3,7 @@
  * @flow
  */
 import lodash from 'lodash';
+import { Op } from 'sequelize';
 import Model from '../../ModelAbstract/ModelAbstract';
 import Column from '../../Column/Column';
 import type {
@@ -82,7 +83,7 @@ export function formatQueryModelList(model: Model,
                     if (e.association === column.getReference()) {
                         e.where = {
                             [ column.getReferenceKey() ]: {
-                                $like: `${ searchParam.value }%`
+                                [Op.like]: `${ searchParam.value }%`
                             }
                         };
                     }
@@ -90,12 +91,12 @@ export function formatQueryModelList(model: Model,
                 });
             } else if (column.getField() && column.isEmptyValue()) {
                 whereSearch[ column.getField() ] = {
-                    $like: `${ searchParam.value }%`
+                    [Op.like]: `${ searchParam.value }%`
                 };
             }
         });
         if (Object.keys(whereSearch).length) {
-            query.where = lodash.merge(query.where, { $or: whereSearch });
+            query.where = lodash.merge(query.where, { [Op.or]: whereSearch });
         }
     }
 


### PR DESCRIPTION
Sequelize docs advise against operator aliases, as they are a vector
opening up the possibility of injecting an Object with string operators
to Sequelize.
More info here:
http://docs.sequelizejs.com/manual/tutorial/querying.html#operators On

This changeset removes the use of sequelize operator aliases from the
package 'core'.