### PR TITLE
Stop using sequelize operator aliases on package 'extensions', as advised for security reasons

### DIFF
--- a/packages/extensions/src/FieldType/Reference/API.js
+++ b/packages/extensions/src/FieldType/Reference/API.js
@@ -1,6 +1,7 @@
 // @flow
 import lodash from 'lodash';
 import { Registry, ModelAbstract } from '@admin-interface/core';
+import { Op } from 'sequelize';
 
 /**
  * Reference API Controller.
@@ -55,12 +56,12 @@ const Controller = {
                     const items = await Model.getModel().findAll({
                         limit: 10,
                         where: {
-                            $or: {
+                            [Op.or]: {
                                 [ label ]: {
-                                    $like: `%${ search }%`
+                                    [Op.like]: `%${ search }%`
                                 },
                                 [ key ]:   {
-                                    $like: `${ search }`
+                                    [Op.like]: `${ search }`
                                 }
                             }
                         }


### PR DESCRIPTION
Sequelize docs advise against operator aliases, as they are a vector
opening up the possibility of injecting an Object with string operators
to Sequelize.
More info here:
http://docs.sequelizejs.com/manual/tutorial/querying.html#operators  
    
This changeset removes the use of sequelize operator aliases from the
package 'extensions'.