### PR TITLE
Dont limit admin-interface to be required at the root level

### DIFF
--- a/packages/core/src/Utils/Yaml/Parser.js
+++ b/packages/core/src/Utils/Yaml/Parser.js
@@ -46,7 +46,7 @@ export function configParser(obj: any, dirname: string, type: any = {}, cache: {
 
                     if (!cache[ moduleName ]) {
                         // eslint-disable-next-line no-param-reassign
-                        cache[ moduleName ] = globby.sync(`${ Registry.getRepository('App').get('cwd')  }/node_modules/**/**/${ moduleName }/`, {
+                        cache[ moduleName ] = globby.sync(`${ process.cwd() }/node_modules/**/**/${ moduleName }/`, {
                             nodir: false
                         })[ 0 ];
                     }


### PR DESCRIPTION
The 'configParser' method of 'core' 's package 'Util/Yarml/Parser'
populates a cache by searching modules inside the project's
'node_modules/' directory.

The problem here is that it achieves this purpose by searching in `${
  Registry.getRepository('App').get('cwd')  }/node_modules/`.
Since `Registry.getRepository('App').get('cwd')` seems to evaluate to
the point in the project tree in which admin-interface was required,
this introduces quite a heavy limitation: admin-interface must be
required at the root level of the project (or, more precisely: at the
same level than the 'node_modules/' directory); otherwise,
'node_modules/' directory won't be found.

Since the functionality achieved by
`Registry.getRepository('App').get('cwd')` is already provided by node's
`process.cwd()`, this changeset replaces the first with the latter.